### PR TITLE
feat: support License Manager / Office SPLA pricing (Catalog-absent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ graph TB
 - **Dynamic Guide Generation**: Guides are generated dynamically by analyzing SKUs from the Cloud Billing Catalog API
 - **Free Tier Information**: Automatically fetched from GCP documentation and included in the guide
 - **Universal Coverage**: Works with all GCP services - no hardcoded service list
+- **Catalog-absent products**: A small curated supplemental catalog covers products missing from the Cloud Billing Catalog API (currently License Manager / Microsoft Office SPLA). These use synthetic `SUPPLEMENTAL-*` IDs and expose `billing_model=existence` when cost accrues from resource existence (e.g. `license_count`), not metered runtime.
 
 The tool analyzes available SKUs to determine:
 - Required parameters (region, instance type, storage, etc.)
@@ -64,6 +65,7 @@ The tool analyzes available SKUs to determine:
 - Free tier quotas (when available)
 - Cost optimization tips
 
+> **Note**: Supplemental list prices are taken from official Google Cloud documentation and may lag docs updates. Prefer the `source_url` on supplemental SKU/price responses when verifying.
 ## Quick Start
 
 ### Prerequisites
@@ -361,9 +363,11 @@ gcp-cost-mcp-server/
 │   │   ├── scraper.go           # GCP documentation scraper
 │   │   └── patterns.go          # Regex patterns for extraction
 │   ├── pricing/
-│   │   └── client.go            # Cloud Billing Catalog API client
+│   │   ├── client.go            # Cloud Billing Catalog API client
+│   │   └── supplemental/        # Curated Catalog-absent pricing (License Manager / Office SPLA)
 │   └── tools/
 │       ├── deps.go                  # Consumer-side interfaces (PricingClient, FreeTierProvider)
+│       ├── supplemental_client.go   # Merges supplemental catalog into PricingClient
 │       ├── get_estimation_guide.go  # Dynamic guide generator
 │       ├── guide_builder.go         # SKU analysis for guide generation
 │       ├── service_lookup.go        # Service name → service ID resolution
@@ -372,7 +376,6 @@ gcp-cost-mcp-server/
 │       ├── list_skus.go
 │       └── get_sku_price.go
 ```
-
 ### Tool Design
 
 ```mermaid

--- a/internal/pricing/supplemental/catalog.go
+++ b/internal/pricing/supplemental/catalog.go
@@ -1,0 +1,325 @@
+// Package supplemental provides curated pricing for Google Cloud products
+// that are absent from the Cloud Billing Catalog API.
+//
+// Prices and billing rules are sourced from official Google Cloud
+// documentation and must be reviewed when docs change.
+package supplemental
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/nozomi-koborinai/gcp-cost-mcp-server/internal/pricing"
+)
+
+const (
+	// ServiceIDLicenseManager is the synthetic service ID for License Manager.
+	// It is not a Cloud Billing Catalog service ID.
+	ServiceIDLicenseManager = "SUPPLEMENTAL-LICENSE-MANAGER"
+
+	// SKUIDOfficeLTSC2021ProPlus is the synthetic SKU for Office SPLA pricing.
+	SKUIDOfficeLTSC2021ProPlus = "SUPPLEMENTAL-OFFICE-LTSC-2021-PROPLUS"
+
+	// BillingModelExistence means cost accrues from the resource existing
+	// (e.g. license_count), not from metered runtime usage.
+	BillingModelExistence = "existence"
+
+	officeSourceURL = "https://cloud.google.com/compute/docs/instances/windows/ms-office"
+)
+
+// SKU is a curated billable item outside the Cloud Billing Catalog.
+type SKU struct {
+	SKUID           string
+	DisplayName     string
+	ServiceID       string
+	Region          string
+	Categories      []string
+	PricePerUnit    float64
+	CurrencyCode    string
+	Unit            string
+	UnitDescription string
+	BillingModel    string
+	BillingNotes    []string
+	SourceURL       string
+	Aliases         []string
+}
+
+// Service is a curated service outside the Cloud Billing Catalog.
+type Service struct {
+	ServiceID       string
+	DisplayName     string
+	Description     string
+	Aliases         []string
+	SKUs            []SKU
+	GuideParameters []GuideParameter
+	PricingFactors  []string
+	Tips            []string
+}
+
+// GuideParameter is a required estimation parameter for a supplemental service.
+type GuideParameter struct {
+	Name        string
+	Description string
+	Required    bool
+	Examples    []string
+	DefaultTip  string
+}
+
+// catalog is the curated set of Catalog-absent products.
+// Keep entries minimal and document-backed.
+var catalog = []Service{
+	{
+		ServiceID:   ServiceIDLicenseManager,
+		DisplayName: "License Manager (Microsoft Office SPLA)",
+		Description: "Google Cloud License Manager for third-party per-user licenses (e.g. Microsoft Office SPLA). Pricing is documented by Google Cloud but is not currently exposed via the Cloud Billing Catalog API.",
+		Aliases: []string{
+			"license manager",
+			"office",
+			"microsoft office",
+			"office spla",
+			"spla",
+			"office ltsc",
+		},
+		SKUs: []SKU{
+			{
+				SKUID:           SKUIDOfficeLTSC2021ProPlus,
+				DisplayName:     "Microsoft Office LTSC 2021 Professional Plus (per user / month)",
+				ServiceID:       ServiceIDLicenseManager,
+				Region:          "global",
+				Categories:      []string{"License", "Microsoft Office", "SPLA"},
+				PricePerUnit:    21.40,
+				CurrencyCode:    "USD",
+				Unit:            "mo",
+				UnitDescription: "user / month",
+				BillingModel:    BillingModelExistence,
+				BillingNotes: []string{
+					"Billed by authorized license count (existence), not by VM runtime or actual Office usage.",
+					"Billing starts when a License Configuration is created; charges are not prorated within the calendar month.",
+					"Reducing or deactivating licenses takes effect in the next calendar month; increases apply immediately.",
+					"Terraform resource google_license_manager_configuration bills via license_count.",
+					"List price sourced from Google Cloud docs; may change — verify SourceURL.",
+				},
+				SourceURL: officeSourceURL,
+				Aliases: []string{
+					"office",
+					"microsoft office",
+					"office spla",
+					"proplus",
+					"ltsc 2021",
+				},
+			},
+		},
+		GuideParameters: []GuideParameter{
+			{
+				Name:        "license_count",
+				Description: "Number of authorized users (licenses) in the License Configuration. You are billed for this count regardless of whether users actually open Office.",
+				Required:    true,
+				Examples:    []string{"1", "10", "50"},
+				DefaultTip:  "Match google_license_manager_configuration.license_count / authorized users.",
+			},
+			{
+				Name:        "product",
+				Description: "License Manager product. Currently documented: Microsoft Office LTSC 2021 Professional Plus (SPLA product_id ProPlusSPLA2021Volume).",
+				Required:    true,
+				Examples:    []string{"Office LTSC 2021 Professional Plus"},
+			},
+		},
+		PricingFactors: []string{
+			"Authorized user count (license_count)",
+			"Calendar-month billing (no mid-month prorating)",
+			"Existence-based: creating the configuration starts billing",
+		},
+		Tips: []string{
+			"This product is absent from the Cloud Billing Catalog API; prices come from official Google Cloud documentation.",
+			"Set license_count carefully before creating the configuration — billing for the current month starts immediately.",
+			"usage_amount for estimate_cost should be the number of authorized users (licenses), not VM hours.",
+			"See " + officeSourceURL,
+		},
+	},
+}
+
+// Services returns all supplemental services as pricing.Service values.
+func Services() []pricing.Service {
+	out := make([]pricing.Service, len(catalog))
+	for i, svc := range catalog {
+		out[i] = pricing.Service{
+			Name:        "services/" + svc.ServiceID,
+			ServiceID:   svc.ServiceID,
+			DisplayName: svc.DisplayName,
+		}
+	}
+	return out
+}
+
+// IsService reports whether serviceID is a supplemental service.
+func IsService(serviceID string) bool {
+	return FindService(serviceID) != nil
+}
+
+// FindService returns the supplemental service for serviceID, or nil.
+func FindService(serviceID string) *Service {
+	for i := range catalog {
+		if catalog[i].ServiceID == serviceID {
+			svc := catalog[i]
+			return &svc
+		}
+	}
+	return nil
+}
+
+// FindServiceByName returns a supplemental service matching name or alias.
+func FindServiceByName(name string) *Service {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "" {
+		return nil
+	}
+	for i := range catalog {
+		svc := &catalog[i]
+		if strings.ToLower(svc.DisplayName) == normalized {
+			return cloneService(svc)
+		}
+		for _, alias := range svc.Aliases {
+			if alias == normalized || strings.Contains(normalized, alias) || strings.Contains(alias, normalized) {
+				return cloneService(svc)
+			}
+		}
+	}
+	return nil
+}
+
+// SKUsForService returns pricing.SKU values for a supplemental service.
+func SKUsForService(serviceID string) []pricing.SKU {
+	svc := FindService(serviceID)
+	if svc == nil {
+		return nil
+	}
+	out := make([]pricing.SKU, len(svc.SKUs))
+	for i, sku := range svc.SKUs {
+		out[i] = toPricingSKU(sku)
+	}
+	return out
+}
+
+// FindSKU returns the supplemental SKU for skuID, or nil.
+func FindSKU(skuID string) *SKU {
+	for i := range catalog {
+		for j := range catalog[i].SKUs {
+			if catalog[i].SKUs[j].SKUID == skuID {
+				sku := catalog[i].SKUs[j]
+				return &sku
+			}
+		}
+	}
+	return nil
+}
+
+// LookupSKUMeta returns supplemental SKU metadata when skuID is curated.
+func LookupSKUMeta(skuID string) *SKU {
+	return FindSKU(skuID)
+}
+
+// PriceResponse builds a GetPriceResponse for a supplemental SKU.
+// Only USD list prices are curated; other currency codes return an error.
+func PriceResponse(skuID, currencyCode string) (*pricing.GetPriceResponse, error) {
+	sku := FindSKU(skuID)
+	if sku == nil {
+		return nil, fmt.Errorf("supplemental SKU not found: %s", skuID)
+	}
+
+	currency := currencyCode
+	if currency == "" {
+		currency = "USD"
+	}
+	if !strings.EqualFold(currency, sku.CurrencyCode) {
+		return nil, fmt.Errorf(
+			"supplemental SKU %s only has a documented list price in %s (requested %s); see %s",
+			sku.SKUID, sku.CurrencyCode, currency, sku.SourceURL,
+		)
+	}
+
+	units, nanos := splitMoney(sku.PricePerUnit)
+	return &pricing.GetPriceResponse{
+		Name:         "skus/" + sku.SKUID + "/price",
+		CurrencyCode: sku.CurrencyCode,
+		SKUPrices: []pricing.SKUPrice{
+			{
+				ConsumptionModel:            "on-demand",
+				ConsumptionModelDescription: "Documented list price (Cloud Billing Catalog absent)",
+				ValueType:                   "rate",
+				Rate: &pricing.Rate{
+					Tiers: []pricing.Tier{
+						{
+							StartAmount: pricing.Amount{Value: "0"},
+							ListPrice: pricing.Money{
+								CurrencyCode: sku.CurrencyCode,
+								Units:        units,
+								Nanos:        nanos,
+							},
+						},
+					},
+					UnitInfo: pricing.UnitInfo{
+						Unit:            sku.Unit,
+						UnitDescription: sku.UnitDescription,
+					},
+					AggregationInfo: pricing.AggregationInfo{
+						Level:    "ACCOUNT",
+						Interval: "MONTHLY",
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func toPricingSKU(sku SKU) pricing.SKU {
+	categories := make([]pricing.TaxonomyCategory, len(sku.Categories))
+	for i, c := range sku.Categories {
+		categories[i] = pricing.TaxonomyCategory{Category: c}
+	}
+
+	geo := pricing.GeoTaxonomy{Type: "GLOBAL"}
+	if sku.Region != "" && !strings.EqualFold(sku.Region, "global") {
+		geo = pricing.GeoTaxonomy{
+			Type: "REGIONAL",
+			RegionalMetadata: pricing.RegionalMetadata{
+				Region: pricing.Region{Region: sku.Region},
+			},
+		}
+	}
+
+	return pricing.SKU{
+		Name:        "skus/" + sku.SKUID,
+		SKUID:       sku.SKUID,
+		DisplayName: sku.DisplayName,
+		Service:     "services/" + sku.ServiceID,
+		ProductTaxonomy: pricing.ProductTaxonomy{
+			TaxonomyCategories: categories,
+		},
+		GeoTaxonomy: geo,
+	}
+}
+
+func cloneService(svc *Service) *Service {
+	if svc == nil {
+		return nil
+	}
+	cp := *svc
+	return &cp
+}
+
+// splitMoney converts a decimal dollar amount into Cloud Billing Money fields.
+func splitMoney(amount float64) (units string, nanos int64) {
+	if amount < 0 {
+		amount = 0
+	}
+	whole := math.Floor(amount)
+	frac := amount - whole
+	// Round nanos to avoid float residue (e.g. 0.40 -> 400000000).
+	n := int64(math.Round(frac * 1e9))
+	if n >= 1e9 {
+		whole++
+		n = 0
+	}
+	return fmt.Sprintf("%.0f", whole), n
+}

--- a/internal/pricing/supplemental/catalog_test.go
+++ b/internal/pricing/supplemental/catalog_test.go
@@ -1,0 +1,102 @@
+package supplemental
+
+import (
+	"testing"
+)
+
+func TestServicesIncludesLicenseManager(t *testing.T) {
+	services := Services()
+	if len(services) == 0 {
+		t.Fatal("expected at least one supplemental service")
+	}
+	found := false
+	for _, svc := range services {
+		if svc.ServiceID == ServiceIDLicenseManager {
+			found = true
+			if svc.DisplayName == "" {
+				t.Error("License Manager display name is empty")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("License Manager service %q not found", ServiceIDLicenseManager)
+	}
+}
+
+func TestFindServiceByNameAliases(t *testing.T) {
+	names := []string{
+		"License Manager",
+		"license manager",
+		"Office",
+		"office spla",
+		"SPLA",
+		"Microsoft Office",
+	}
+	for _, name := range names {
+		svc := FindServiceByName(name)
+		if svc == nil {
+			t.Fatalf("FindServiceByName(%q) = nil, want License Manager", name)
+		}
+		if svc.ServiceID != ServiceIDLicenseManager {
+			t.Fatalf("FindServiceByName(%q).ServiceID = %q, want %q", name, svc.ServiceID, ServiceIDLicenseManager)
+		}
+	}
+}
+
+func TestOfficeSKUPrice(t *testing.T) {
+	sku := FindSKU(SKUIDOfficeLTSC2021ProPlus)
+	if sku == nil {
+		t.Fatal("Office SKU not found")
+	}
+	if sku.PricePerUnit != 21.40 {
+		t.Fatalf("PricePerUnit = %v, want 21.40", sku.PricePerUnit)
+	}
+	if sku.BillingModel != BillingModelExistence {
+		t.Fatalf("BillingModel = %q, want %q", sku.BillingModel, BillingModelExistence)
+	}
+	if sku.SourceURL == "" {
+		t.Fatal("SourceURL is empty")
+	}
+
+	resp, err := PriceResponse(SKUIDOfficeLTSC2021ProPlus, "USD")
+	if err != nil {
+		t.Fatalf("PriceResponse: %v", err)
+	}
+	if len(resp.SKUPrices) != 1 || resp.SKUPrices[0].Rate == nil {
+		t.Fatalf("unexpected price response: %+v", resp)
+	}
+	price, err := resp.SKUPrices[0].Rate.Tiers[0].ListPrice.UnitPrice()
+	if err != nil {
+		t.Fatalf("UnitPrice: %v", err)
+	}
+	if price != 21.40 {
+		t.Fatalf("UnitPrice = %v, want 21.40", price)
+	}
+
+	if _, err := PriceResponse(SKUIDOfficeLTSC2021ProPlus, "JPY"); err == nil {
+		t.Fatal("expected error for non-USD currency")
+	}
+}
+
+func TestSKUsForService(t *testing.T) {
+	skus := SKUsForService(ServiceIDLicenseManager)
+	if len(skus) != 1 {
+		t.Fatalf("SKUsForService len = %d, want 1", len(skus))
+	}
+	if skus[0].SKUID != SKUIDOfficeLTSC2021ProPlus {
+		t.Fatalf("SKUID = %q, want %q", skus[0].SKUID, SKUIDOfficeLTSC2021ProPlus)
+	}
+	if skus[0].GeoTaxonomy.Type != "GLOBAL" {
+		t.Fatalf("GeoTaxonomy.Type = %q, want GLOBAL", skus[0].GeoTaxonomy.Type)
+	}
+}
+
+func TestSplitMoney(t *testing.T) {
+	units, nanos := splitMoney(21.40)
+	if units != "21" {
+		t.Fatalf("units = %q, want 21", units)
+	}
+	if nanos != 400000000 {
+		t.Fatalf("nanos = %d, want 400000000", nanos)
+	}
+}

--- a/internal/tools/estimate_cost.go
+++ b/internal/tools/estimate_cost.go
@@ -43,6 +43,10 @@ type CostBreakdown struct {
 	BillableUsage     float64 `json:"billable_usage"`
 	FreeTierNote      string  `json:"free_tier_note,omitempty"`
 	FreeTierSourceURL string  `json:"free_tier_source_url,omitempty"`
+	// Supplemental / Catalog-absent billing metadata (Issue #18)
+	BillingModel string   `json:"billing_model,omitempty"`
+	BillingNotes []string `json:"billing_notes,omitempty"`
+	SourceURL    string   `json:"source_url,omitempty"`
 }
 
 // EstimateCostOutput is the output of the estimate_cost tool
@@ -226,6 +230,7 @@ func runEstimateCost(ctx context.Context, client PricingClient, freeTierService 
 		)
 	}
 	estimate.CostBreakdown = breakdownDesc
+	enrichCostBreakdown(&estimate)
 
 	return &EstimateCostOutput{
 		Estimate: estimate,

--- a/internal/tools/get_estimation_guide.go
+++ b/internal/tools/get_estimation_guide.go
@@ -96,6 +96,17 @@ func runGetEstimationGuide(ctx context.Context, pricingClient PricingClient, fre
 		return nil, fmt.Errorf("service_name is required")
 	}
 
+	// Catalog-absent products (License Manager / Office SPLA) get a curated guide.
+	if guide := supplementalGuide(input.ServiceName); guide != nil {
+		if freeTierService != nil {
+			guide.FreeTier = &FreeTierSummary{Available: false}
+		}
+		return &GetEstimationGuideOutput{
+			Guide:             *guide,
+			SuggestedQuestion: buildSuggestedQuestion(guide),
+		}, nil
+	}
+
 	// Find the service ID
 	serviceID, displayName, err := findServiceByName(ctx, pricingClient, input.ServiceName)
 	if err != nil {

--- a/internal/tools/get_sku_price.go
+++ b/internal/tools/get_sku_price.go
@@ -41,6 +41,9 @@ type PriceInfo struct {
 	Tiers            []PricingTier        `json:"tiers"`
 	AggregationInfo  string               `json:"aggregation_info,omitempty"`
 	AllPricingModels []ConsumptionPricing `json:"all_pricing_models,omitempty"`
+	BillingModel     string               `json:"billing_model,omitempty"`
+	BillingNotes     []string             `json:"billing_notes,omitempty"`
+	SourceURL        string               `json:"source_url,omitempty"`
 }
 
 // GetSKUPriceOutput is the output of the get_sku_price tool
@@ -137,6 +140,8 @@ func runGetSKUPrice(ctx context.Context, client PricingClient, input GetSKUPrice
 	if len(allModels) > 0 {
 		priceInfo.AllPricingModels = allModels
 	}
+
+	enrichPriceInfo(&priceInfo)
 
 	return &GetSKUPriceOutput{
 		Price: priceInfo,

--- a/internal/tools/helpers_test.go
+++ b/internal/tools/helpers_test.go
@@ -23,6 +23,8 @@ func TestGetServiceAliases(t *testing.T) {
 		{"gae", "app engine"},
 		{"gce", "compute engine"},
 		{"pubsub", "pub/sub"},
+		{"office", "license manager (microsoft office spla)"},
+		{"spla", "license manager (microsoft office spla)"},
 	}
 
 	for _, tt := range tests {

--- a/internal/tools/list_services.go
+++ b/internal/tools/list_services.go
@@ -33,7 +33,7 @@ type ListServicesOutput struct {
 	TotalReturned int           `json:"total_returned"`
 }
 
-const listServicesDescription = "Lists publicly available Google Cloud services with their IDs and display names. Supports filtering by name and excluding third-party marketplace products. Use the service_id to query SKUs for a specific service."
+const listServicesDescription = "Lists publicly available Google Cloud services with their IDs and display names. Supports filtering by name and excluding third-party marketplace products. Use the service_id to query SKUs for a specific service. Also includes curated Catalog-absent services such as License Manager (Office SPLA)."
 
 // NewListServices creates a tool that lists all Google Cloud services
 func NewListServices(g *genkit.Genkit, client PricingClient) ai.Tool {
@@ -123,6 +123,7 @@ var gcpCoreServicePrefixes = []string{
 	"carbon ", "active assist", "recommender",
 	"backup and dr", "cloud console",
 	"gemini",
+	"license manager",
 }
 
 func isCoreGCPService(displayName string) bool {

--- a/internal/tools/list_skus.go
+++ b/internal/tools/list_skus.go
@@ -23,10 +23,13 @@ type ListSKUsInput struct {
 
 // SKUInfo represents simplified SKU information
 type SKUInfo struct {
-	SKUID       string   `json:"sku_id"`
-	DisplayName string   `json:"display_name"`
-	Region      string   `json:"region,omitempty"`
-	Categories  []string `json:"categories,omitempty"`
+	SKUID        string   `json:"sku_id"`
+	DisplayName  string   `json:"display_name"`
+	Region       string   `json:"region,omitempty"`
+	Categories   []string `json:"categories,omitempty"`
+	BillingModel string   `json:"billing_model,omitempty"`
+	BillingNotes []string `json:"billing_notes,omitempty"`
+	SourceURL    string   `json:"source_url,omitempty"`
 }
 
 // ListSKUsOutput is the output of the list_skus tool
@@ -37,7 +40,7 @@ type ListSKUsOutput struct {
 	ServiceID     string    `json:"service_id"`
 }
 
-const listSKUsDescription = "Lists SKUs (Stock Keeping Units) for a specific Google Cloud service. Each SKU represents a billable item with its own pricing. Use the sku_id to get detailed pricing information. Supports optional filtering by region, keyword (display name), and category to quickly find specific SKUs without manual pagination."
+const listSKUsDescription = "Lists SKUs (Stock Keeping Units) for a specific Google Cloud service. Each SKU represents a billable item with its own pricing. Use the sku_id to get detailed pricing information. Supports optional filtering by region, keyword (display name), and category to quickly find specific SKUs without manual pagination. Includes curated Catalog-absent products (e.g. License Manager / Office SPLA) when querying their supplemental service_id; those SKUs may include billing_model=existence."
 
 // NewListSKUs creates a tool that lists SKUs for a specific Google Cloud service
 func NewListSKUs(g *genkit.Genkit, client PricingClient) ai.Tool {
@@ -107,12 +110,12 @@ func convertSKUs(raw []pricing.SKU) []SKUInfo {
 			region = "global"
 		}
 
-		skus[i] = SKUInfo{
+		skus[i] = enrichSKUInfo(SKUInfo{
 			SKUID:       sku.SKUID,
 			DisplayName: sku.DisplayName,
 			Region:      region,
 			Categories:  categories,
-		}
+		})
 	}
 	return skus
 }

--- a/internal/tools/service_lookup.go
+++ b/internal/tools/service_lookup.go
@@ -58,5 +58,10 @@ func getServiceAliases() map[string]string {
 		"2nd gen functions":   "cloud functions",
 		"pubsub":              "pub/sub",
 		"cloud pubsub":        "pub/sub",
+		"license manager":  "license manager (microsoft office spla)",
+		"office":           "license manager (microsoft office spla)",
+		"microsoft office": "license manager (microsoft office spla)",
+		"office spla":      "license manager (microsoft office spla)",
+		"spla":             "license manager (microsoft office spla)",
 	}
 }

--- a/internal/tools/supplemental_client.go
+++ b/internal/tools/supplemental_client.go
@@ -1,0 +1,164 @@
+package tools
+
+import (
+	"context"
+
+	"github.com/nozomi-koborinai/gcp-cost-mcp-server/internal/pricing"
+	"github.com/nozomi-koborinai/gcp-cost-mcp-server/internal/pricing/supplemental"
+)
+
+// WithSupplemental wraps a PricingClient so Catalog-absent products
+// (License Manager / Office SPLA, etc.) appear in list/price/estimate flows.
+func WithSupplemental(inner PricingClient) PricingClient {
+	if inner == nil {
+		return nil
+	}
+	return &supplementalClient{inner: inner}
+}
+
+type supplementalClient struct {
+	inner PricingClient
+}
+
+func (c *supplementalClient) ListServices(ctx context.Context, pageSize int, pageToken string) (*pricing.ListServicesResponse, error) {
+	resp, err := c.inner.ListServices(ctx, pageSize, pageToken)
+	if err != nil {
+		return nil, err
+	}
+	// Append curated services on the final page so unfiltered pagination
+	// still surfaces Catalog-absent products.
+	if resp.NextPageToken == "" {
+		resp.Services = mergeServices(resp.Services, supplemental.Services())
+	}
+	return resp, nil
+}
+
+func (c *supplementalClient) ListAllServices(ctx context.Context) ([]pricing.Service, error) {
+	services, err := c.inner.ListAllServices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return mergeServices(services, supplemental.Services()), nil
+}
+
+func (c *supplementalClient) ListSKUs(ctx context.Context, serviceID string, pageSize int, pageToken string) (*pricing.ListSKUsResponse, error) {
+	if supplemental.IsService(serviceID) {
+		skus := supplemental.SKUsForService(serviceID)
+		return &pricing.ListSKUsResponse{SKUs: skus}, nil
+	}
+	return c.inner.ListSKUs(ctx, serviceID, pageSize, pageToken)
+}
+
+func (c *supplementalClient) ListAllSKUs(ctx context.Context, serviceID string) ([]pricing.SKU, error) {
+	if supplemental.IsService(serviceID) {
+		return supplemental.SKUsForService(serviceID), nil
+	}
+	return c.inner.ListAllSKUs(ctx, serviceID)
+}
+
+func (c *supplementalClient) GetSKUPrice(ctx context.Context, skuID, currencyCode string) (*pricing.GetPriceResponse, error) {
+	if supplemental.FindSKU(skuID) != nil {
+		return supplemental.PriceResponse(skuID, currencyCode)
+	}
+	return c.inner.GetSKUPrice(ctx, skuID, currencyCode)
+}
+
+func mergeServices(base, extra []pricing.Service) []pricing.Service {
+	seen := make(map[string]bool, len(base))
+	out := make([]pricing.Service, 0, len(base)+len(extra))
+	for _, svc := range base {
+		seen[svc.ServiceID] = true
+		out = append(out, svc)
+	}
+	for _, svc := range extra {
+		if seen[svc.ServiceID] {
+			continue
+		}
+		out = append(out, svc)
+	}
+	return out
+}
+
+// enrichSKUInfo adds supplemental billing metadata when the SKU is curated.
+func enrichSKUInfo(info SKUInfo) SKUInfo {
+	sku := supplemental.LookupSKUMeta(info.SKUID)
+	if sku == nil {
+		return info
+	}
+	info.BillingModel = sku.BillingModel
+	info.BillingNotes = append([]string(nil), sku.BillingNotes...)
+	info.SourceURL = sku.SourceURL
+	return info
+}
+
+func enrichPriceInfo(info *PriceInfo) {
+	sku := supplemental.LookupSKUMeta(info.SKUID)
+	if sku == nil {
+		return
+	}
+	info.BillingModel = sku.BillingModel
+	info.BillingNotes = append([]string(nil), sku.BillingNotes...)
+	info.SourceURL = sku.SourceURL
+}
+
+func enrichCostBreakdown(estimate *CostBreakdown) {
+	sku := supplemental.LookupSKUMeta(estimate.SKUID)
+	if sku == nil {
+		return
+	}
+	estimate.BillingModel = sku.BillingModel
+	estimate.BillingNotes = append([]string(nil), sku.BillingNotes...)
+	estimate.SourceURL = sku.SourceURL
+	if estimate.ServiceName == "" {
+		if svc := supplemental.FindService(sku.ServiceID); svc != nil {
+			estimate.ServiceName = svc.DisplayName
+		}
+	}
+}
+
+func supplementalGuide(serviceName string) *EstimationGuide {
+	svc := supplemental.FindServiceByName(serviceName)
+	if svc == nil {
+		return nil
+	}
+
+	params := make([]RequiredParameter, len(svc.GuideParameters))
+	for i, p := range svc.GuideParameters {
+		params[i] = RequiredParameter{
+			Name:        p.Name,
+			Description: p.Description,
+			Required:    p.Required,
+			Examples:    append([]string(nil), p.Examples...),
+			DefaultTip:  p.DefaultTip,
+		}
+	}
+
+	return &EstimationGuide{
+		ServiceName:        svc.DisplayName,
+		ServiceID:          svc.ServiceID,
+		ServiceDescription: svc.Description,
+		Parameters:         params,
+		PricingFactors:     append([]string(nil), svc.PricingFactors...),
+		Tips:               append([]string(nil), svc.Tips...),
+		AvailableRegions:   []string{"global"},
+		SKUCategories:      skuCategories(svc),
+	}
+}
+
+func skuCategories(svc *supplemental.Service) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, sku := range svc.SKUs {
+		for _, c := range sku.Categories {
+			if seen[c] {
+				continue
+			}
+			seen[c] = true
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// Ensure the wrapper satisfies PricingClient.
+var _ PricingClient = (*supplementalClient)(nil)

--- a/internal/tools/supplemental_test.go
+++ b/internal/tools/supplemental_test.go
@@ -1,0 +1,164 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nozomi-koborinai/gcp-cost-mcp-server/internal/pricing"
+	"github.com/nozomi-koborinai/gcp-cost-mcp-server/internal/pricing/supplemental"
+)
+
+func TestWithSupplemental_ListServicesFindsOffice(t *testing.T) {
+	inner := &fakePricingClient{
+		allServices: []pricing.Service{
+			{ServiceID: "S1", DisplayName: "Cloud Run"},
+			{ServiceID: "S2", DisplayName: "Compute Engine"},
+		},
+	}
+	client := WithSupplemental(inner)
+
+	out, err := runListServices(context.Background(), client, ListServicesInput{Name: "Office"})
+	if err != nil {
+		t.Fatalf("runListServices: %v", err)
+	}
+	if out.TotalReturned != 1 {
+		t.Fatalf("TotalReturned = %d, want 1; services=%v", out.TotalReturned, out.Services)
+	}
+	if out.Services[0].ServiceID != supplemental.ServiceIDLicenseManager {
+		t.Fatalf("ServiceID = %q, want %q", out.Services[0].ServiceID, supplemental.ServiceIDLicenseManager)
+	}
+}
+
+func TestWithSupplemental_ListServicesAppendsOnLastPage(t *testing.T) {
+	inner := &fakePricingClient{
+		listServicesResp: &pricing.ListServicesResponse{
+			Services: []pricing.Service{{ServiceID: "S1", DisplayName: "Cloud Run"}},
+		},
+	}
+	client := WithSupplemental(inner)
+
+	out, err := runListServices(context.Background(), client, ListServicesInput{})
+	if err != nil {
+		t.Fatalf("runListServices: %v", err)
+	}
+	found := false
+	for _, svc := range out.Services {
+		if svc.ServiceID == supplemental.ServiceIDLicenseManager {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("License Manager not appended; services=%v", out.Services)
+	}
+}
+
+func TestWithSupplemental_ListSKUsAndEstimateOffice(t *testing.T) {
+	inner := &fakePricingClient{
+		// Ensure Catalog path is not used for supplemental IDs.
+		listSKUsErr: errors.New("should not call catalog for supplemental service"),
+		priceErr:    errors.New("should not call catalog for supplemental SKU"),
+	}
+	client := WithSupplemental(inner)
+
+	skusOut, err := runListSKUs(context.Background(), client, ListSKUsInput{
+		ServiceID: supplemental.ServiceIDLicenseManager,
+		Keyword:   "Office",
+	})
+	if err != nil {
+		t.Fatalf("runListSKUs: %v", err)
+	}
+	if skusOut.TotalReturned != 1 {
+		t.Fatalf("TotalReturned = %d, want 1", skusOut.TotalReturned)
+	}
+	sku := skusOut.SKUs[0]
+	if sku.SKUID != supplemental.SKUIDOfficeLTSC2021ProPlus {
+		t.Fatalf("SKUID = %q, want %q", sku.SKUID, supplemental.SKUIDOfficeLTSC2021ProPlus)
+	}
+	if sku.BillingModel != supplemental.BillingModelExistence {
+		t.Fatalf("BillingModel = %q, want %q", sku.BillingModel, supplemental.BillingModelExistence)
+	}
+	if len(sku.BillingNotes) == 0 || sku.SourceURL == "" {
+		t.Fatalf("expected billing notes and source URL, got notes=%v url=%q", sku.BillingNotes, sku.SourceURL)
+	}
+
+	priceOut, err := runGetSKUPrice(context.Background(), client, GetSKUPriceInput{
+		SKUID: sku.SKUID,
+	})
+	if err != nil {
+		t.Fatalf("runGetSKUPrice: %v", err)
+	}
+	if priceOut.Price.BillingModel != supplemental.BillingModelExistence {
+		t.Fatalf("price BillingModel = %q", priceOut.Price.BillingModel)
+	}
+	if len(priceOut.Price.Tiers) != 1 || priceOut.Price.Tiers[0].PricePerUnit != 21.40 {
+		t.Fatalf("unexpected tiers: %+v", priceOut.Price.Tiers)
+	}
+
+	estOut, err := runEstimateCost(context.Background(), client, nil, EstimateCostInput{
+		SKUID:       sku.SKUID,
+		UsageAmount: 10, // 10 authorized users
+	})
+	if err != nil {
+		t.Fatalf("runEstimateCost: %v", err)
+	}
+	if estOut.Estimate.EstimatedCost != 214.0 {
+		t.Fatalf("EstimatedCost = %v, want 214.0", estOut.Estimate.EstimatedCost)
+	}
+	if estOut.Estimate.BillingModel != supplemental.BillingModelExistence {
+		t.Fatalf("estimate BillingModel = %q", estOut.Estimate.BillingModel)
+	}
+	if estOut.Estimate.ServiceName == "" {
+		t.Fatal("expected ServiceName to be filled from supplemental catalog")
+	}
+}
+
+func TestGetEstimationGuide_LicenseManager(t *testing.T) {
+	// Inner client unused for supplemental guide path.
+	client := WithSupplemental(&fakePricingClient{allServicesErr: errors.New("unused")})
+
+	out, err := runGetEstimationGuide(context.Background(), client, nil, GetEstimationGuideInput{
+		ServiceName: "Office SPLA",
+	})
+	if err != nil {
+		t.Fatalf("runGetEstimationGuide: %v", err)
+	}
+	if out.Guide.ServiceID != supplemental.ServiceIDLicenseManager {
+		t.Fatalf("ServiceID = %q, want %q", out.Guide.ServiceID, supplemental.ServiceIDLicenseManager)
+	}
+	if len(out.Guide.Parameters) == 0 {
+		t.Fatal("expected guide parameters")
+	}
+	foundLicenseCount := false
+	for _, p := range out.Guide.Parameters {
+		if p.Name == "license_count" {
+			foundLicenseCount = true
+		}
+	}
+	if !foundLicenseCount {
+		t.Fatalf("license_count parameter missing: %+v", out.Guide.Parameters)
+	}
+	joinedTips := strings.Join(out.Guide.Tips, " ")
+	if !strings.Contains(strings.ToLower(joinedTips), "catalog") {
+		t.Fatalf("expected tip mentioning Catalog absence, tips=%v", out.Guide.Tips)
+	}
+}
+
+func TestWithSupplemental_PassthroughCatalogSKU(t *testing.T) {
+	inner := &fakePricingClient{
+		priceResp: flatRatePriceResp("USD", "1", 0, "h"),
+	}
+	client := WithSupplemental(inner)
+
+	out, err := runGetSKUPrice(context.Background(), client, GetSKUPriceInput{SKUID: "0008-F633-76AA"})
+	if err != nil {
+		t.Fatalf("runGetSKUPrice: %v", err)
+	}
+	if out.Price.BillingModel != "" {
+		t.Fatalf("catalog SKU should not get supplemental billing_model, got %q", out.Price.BillingModel)
+	}
+	if out.Price.Tiers[0].PricePerUnit != 1.0 {
+		t.Fatalf("PricePerUnit = %v, want 1.0", out.Price.Tiers[0].PricePerUnit)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -52,6 +52,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create Pricing API client: %v", err)
 	}
+	// Merge Catalog-absent curated pricing (License Manager / Office SPLA).
+	pricingClientWrapped := tools.WithSupplemental(pricingClient)
 
 	// Create FreeTierService for free tier information retrieval
 	freeTierService := freetier.NewService()
@@ -59,11 +61,11 @@ func main() {
 
 	// Define tools
 	toolList := []ai.Tool{
-		tools.NewGetEstimationGuide(g, pricingClient, freeTierService), // Should be called first to understand requirements
-		tools.NewListServices(g, pricingClient),
-		tools.NewListSKUs(g, pricingClient),
-		tools.NewGetSKUPrice(g, pricingClient),
-		tools.NewEstimateCost(g, pricingClient, freeTierService), // Now includes free tier auto-apply
+		tools.NewGetEstimationGuide(g, pricingClientWrapped, freeTierService), // Should be called first to understand requirements
+		tools.NewListServices(g, pricingClientWrapped),
+		tools.NewListSKUs(g, pricingClientWrapped),
+		tools.NewGetSKUPrice(g, pricingClientWrapped),
+		tools.NewEstimateCost(g, pricingClientWrapped, freeTierService), // Now includes free tier auto-apply
 	}
 
 	// Log registered tools


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #18 by adding a curated **supplemental catalog** for products missing from the Cloud Billing Catalog API.

- Adds `License Manager (Microsoft Office SPLA)` as a synthetic service (`SUPPLEMENTAL-LICENSE-MANAGER`)
- Exposes Office LTSC 2021 Professional Plus at **$21.40 / user / month** (from [Google Cloud docs](https://cloud.google.com/compute/docs/instances/windows/ms-office))
- Marks billing as `billing_model=existence` with notes about calendar-month / non-prorated / `license_count` billing
- Wires supplemental entries into existing tools via `WithSupplemental` (no new MCP tool)
- Adds a curated `get_estimation_guide` path for Office / SPLA / License Manager aliases

## How to verify

```bash
go test ./...
```

Manual flow (with ADC):

1. `list_services` with `name=Office` → License Manager
2. `list_skus` with that `service_id` → Office SPLA SKU + `billing_model=existence`
3. `estimate_cost` with `usage_amount=10` → `$214.00`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6838-d27d-72e2-aa54-228314bda4c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6838-d27d-72e2-aa54-228314bda4c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

